### PR TITLE
Endpoints (EEP) Support

### DIFF
--- a/src/aims-client.ts
+++ b/src/aims-client.ts
@@ -1,8 +1,9 @@
 /**
  * Module to deal with available AIMS Public API endpoints
  */
+import { AlLocation, AlResponseValidationError } from '@al/common';
 import { AlApiClient, AlDefaultClient, APIRequestParams, AIMSSessionDescriptor } from '@al/client';
-import { AIMSAccount, AIMSUser, AIMSAuthentication, AIMSAuthenticationTokenInfo, AIMSRole, AIMSAccessKey } from './types';
+import { AIMSAccount, AIMSUser, AIMSAuthentication, AIMSAuthenticationTokenInfo, AIMSRole, AIMSAccessKey, AIMSOrganization } from './types';
 
 export class AIMSClientInstance {
 
@@ -196,6 +197,7 @@ export class AIMSClientInstance {
    */
   public async getTokenInfo( accessToken:string ):Promise<AIMSAuthenticationTokenInfo> {
     return this.client.get( {
+      service_stack: AlLocation.GlobalAPI,
       service_name: this.serviceName,
       version: 1,
       path: '/token_info',
@@ -511,6 +513,37 @@ export class AIMSClientInstance {
     });
     return keyDelete;
   }
+
+  /**
+   * Starts/Refreshes an Endpoints Session
+   */
+  async startEndpointsSession():Promise<string> {
+    const requestDescriptor = {
+      service_name: this.serviceName,
+      version: 'v1',
+      path: '/endpoints_session'
+    };
+    return await this.client.get( requestDescriptor )
+                          .then( responseData => {
+                            if ( ! responseData.hasOwnProperty("cookie") ) {
+                              return Promise.reject( new AlResponseValidationError( "Unexpected response format: no 'cookie' property present." ) );
+                            }
+                            return responseData.cookie as string;
+                          } );
+  }
+
+    /**
+     * Retrieve linked organization
+     */
+    async getAccountOrganization( accountId:string ):Promise<AIMSOrganization> {
+      const requestDescriptor = {
+          service_name: this.serviceName,
+          version: 1,
+          account_id: accountId,
+          path: '/organization'
+      };
+      return await this.client.get( requestDescriptor ) as AIMSOrganization;
+    }
 }
 
 /* tslint:disable:variable-name */

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -36,3 +36,12 @@ export interface AIMSAccessKey {
   secret_key?: string;
 }
 
+export interface AIMSOrganization {
+  account_id: string;
+  location_id: string;
+  id: string;
+  version: number;
+  created: AlChangeStamp;
+  modified: AlChangeStamp;
+  url: string;
+}

--- a/test/aims-client.spec.ts
+++ b/test/aims-client.spec.ts
@@ -12,13 +12,14 @@ const queryParams = { foo: 'bar' };
 
 describe('AIMS Client Test Suite:', () => {
   let stub: sinon.SinonSpy;
-  let apiBaseURL;
+  let apiBaseURL, globalBaseURL;
   beforeEach(() => {
+    AlLocatorService.setContext( { environment: "integration" } );
     ALClient.reset()
             .setGlobalParameters( { noEndpointsResolution: true } );
-    AlLocatorService.setContext( { environment: "integration" } );
     stub = sinon.stub(ALClient as any, "axiosRequest").returns( Promise.resolve( { status: 200, data: 'Some result', config: {} } ) );
     apiBaseURL = AlLocatorService.resolveURL( AlLocation.InsightAPI );
+    globalBaseURL = AlLocatorService.resolveURL( AlLocation.GlobalAPI );
   });
   afterEach(() => {
     stub.restore();
@@ -156,7 +157,7 @@ describe('AIMS Client Test Suite:', () => {
       expect( stub.callCount ).to.equal( 1 );
       const payload = stub.args[0][0];
       expect( payload.method ).to.equal( "GET" );
-      expect( payload.url ).to.equal( `${apiBaseURL}/aims/v1/token_info` );
+      expect( payload.url ).to.equal( `${globalBaseURL}/aims/v1/token_info` );
       expect( payload.headers['X-AIMS-Auth-Token'] ).to.equal( 'ABCDEFGHIJKLMNOPQRSTUVWXYZ' );
     } );
   } );


### PR DESCRIPTION
- Added `endpoints_session` "startEndpointsSession" method
- Added account organization mapping method
- Updated `getTokenInfo` method to use global API stack