### PR TITLE
v1.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@al/aims",
-  "version": "1.1.6",
+  "version": "1.2.0",
   "license": "MIT",
   "description": "A client for interacting with the Alert Logic AIMS Public API",
   "author": {


### PR DESCRIPTION
Added a placeholder method to retrieve consolidated user records from a
relationship tree.

Bumped to 1.2 range just for the sake of version pariety with @al/common
and @al/session.